### PR TITLE
WD-27: Week switcher

### DIFF
--- a/src/components/agenda-page/DayOfWeekList.tsx
+++ b/src/components/agenda-page/DayOfWeekList.tsx
@@ -9,7 +9,7 @@ import { useRecoilValue } from "recoil";
 import { getTasksByDay } from "../../domain/TaskUtils";
 import { getWeekdayName } from "../../domain/WeekdayUtils";
 import { Weekday } from "../../schema/Weekday";
-import { weekTasksState } from "../../store";
+import { weekState, weekTasksState } from "../../store";
 import IconButton from "../IconButton";
 import NewTaskForm from "./NewTaskForm";
 import NewTaskPrompt from "./NewTaskPrompt";
@@ -23,12 +23,35 @@ interface DayOfWeekListProps {
 const DayOfWeekList: React.FC<DayOfWeekListProps> = ({ dayOfWeek, uid }) => {
   const [editingDay, setEditingDay] = React.useState(false);
   const [addingNewTask, setAddingNewTask] = React.useState(false);
+  const week = useRecoilValue(weekState);
   const weekTasks = useRecoilValue(weekTasksState);
-  const dayTasks = getTasksByDay(weekTasks, dayOfWeek);
-  const isToday = moment().day() === dayOfWeek;
-  const contClassName = `group w-full mr-1 first:ml-1 last:border-r-0 dark:border-x-neutral-500 bg-gray-200 dark:bg-zinc-700 ${
-    isToday && "border-t-4 border-t-disc-blue"
-  }`;
+
+  const date = React.useMemo(
+    () => moment().week(week).day(dayOfWeek),
+    [week, dayOfWeek]
+  );
+
+  const dayTasks = React.useMemo(
+    () => getTasksByDay(weekTasks, date),
+    [weekTasks, date]
+  );
+
+  const isToday = React.useMemo(
+    () => moment().isSame(date, "date"),
+    [date]
+  );
+
+  const contClassName = React.useMemo(
+    () =>
+      `group w-full mr-1 first:ml-1 last:border-r-0 dark:border-x-neutral-500 bg-gray-200 dark:bg-zinc-700 ${
+        isToday && "border-t-4 border-t-disc-blue"
+      }`,
+    [isToday]
+  );
+
+  const dayOfMonthString = React.useMemo(() => {
+    return `, ${date.format("MMM. DD")}`;
+  }, [date]);
 
   return (
     <div className={contClassName}>
@@ -37,7 +60,12 @@ const DayOfWeekList: React.FC<DayOfWeekListProps> = ({ dayOfWeek, uid }) => {
           !isToday && "pt-2"
         }`}
       >
-        <h2 className="text-lg ml-1 font-bold">{getWeekdayName(dayOfWeek)}</h2>
+        <div className="flex gap-0">
+          <span className="text-lg ml-1 font-bold">
+            {getWeekdayName(dayOfWeek)}
+          </span>
+          <span className="text-lg">{dayOfMonthString}</span>
+        </div>
         <div className="flex gap-3 mr-1">
           <IconButton
             icon={faCirclePlus}

--- a/src/components/agenda-page/WeekSwitcher.tsx
+++ b/src/components/agenda-page/WeekSwitcher.tsx
@@ -21,13 +21,13 @@ const WeekSwitcher: React.FC = () => {
 
   return (
     <div className="flex gap-2 items-center">
-      <IconButton icon={faArrowLeft} onClick={() => handleClick(true)} />
+      <IconButton className="select-none" icon={faArrowLeft} onClick={() => handleClick(true)} />
       <div>
         <span className="text-xl">Week of</span>
         <span className="text-xl font-bold"> {weekTitle}</span>
       </div>
 
-      <IconButton icon={faArrowRight} onClick={() => handleClick(false)} />
+      <IconButton className="select-none" icon={faArrowRight} onClick={() => handleClick(false)} />
     </div>
   );
 };

--- a/src/components/agenda-page/WeekSwitcher.tsx
+++ b/src/components/agenda-page/WeekSwitcher.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { faArrowRight, faArrowLeft } from "@fortawesome/free-solid-svg-icons";
+import IconButton from "../IconButton";
+import moment from "moment";
+import { useRecoilState } from "recoil";
+import { weekState } from "../../store";
+
+const WeekSwitcher: React.FC = () => {
+  const [week, setWeek] = useRecoilState(weekState);
+  const weekTitle = React.useMemo(
+    () => moment().week(week).day(0).format("DD MMM. YYYY"),
+    [week]
+  );
+
+  const handleClick = React.useCallback(
+    (left: boolean) => {
+      left ? setWeek(week - 1) : setWeek(week + 1);
+    },
+    [week, setWeek]
+  );
+
+  return (
+    <div className="flex gap-2 items-center">
+      <IconButton icon={faArrowLeft} onClick={() => handleClick(true)} />
+      <div>
+        <span className="text-xl">Week of</span>
+        <span className="text-xl font-bold"> {weekTitle}</span>
+      </div>
+
+      <IconButton icon={faArrowRight} onClick={() => handleClick(false)} />
+    </div>
+  );
+};
+
+export default WeekSwitcher;

--- a/src/domain/TaskUtils.ts
+++ b/src/domain/TaskUtils.ts
@@ -1,9 +1,9 @@
+import { Moment } from "moment";
 import { EditTaskArgs, Task, taskToServer } from "../schema/Task";
-import { Weekday } from "../schema/Weekday";
 import { editTask } from "../services/tasks";
 
-export const getTasksByDay = (tasks: Task[], day: Weekday): Task[] => {
-  return tasks.filter((t) => t.taskDate.day() === day);
+export const getTasksByDay = (tasks: Task[], day: Moment): Task[] => {
+  return tasks.filter((t) => t.taskDate.isSame(day, "date"));
 };
 
 export const editTaskToServer = async (

--- a/src/domain/WeekdayUtils.ts
+++ b/src/domain/WeekdayUtils.ts
@@ -7,7 +7,7 @@ export const getWeekdayName = (day: Weekday) : string => {
     case Weekday.Monday:
       return "Mon";
     case Weekday.Tuesday:
-      return "Tues";
+      return "Tue";
     case Weekday.Wednesday:
       return "Wed";
     case Weekday.Thursday:

--- a/src/domain/WeekdayUtils.ts
+++ b/src/domain/WeekdayUtils.ts
@@ -3,19 +3,19 @@ import { Weekday } from "../schema/Weekday";
 export const getWeekdayName = (day: Weekday) : string => {
   switch (day) {
     case Weekday.Sunday:
-      return "Sunday";
+      return "Sun";
     case Weekday.Monday:
-      return "Monday";
+      return "Mon";
     case Weekday.Tuesday:
-      return "Tuesday";
+      return "Tues";
     case Weekday.Wednesday:
-      return "Wednesday";
+      return "Wed";
     case Weekday.Thursday:
-      return "Thursday";
+      return "Thu";
     case Weekday.Friday:
-      return "Friday";
+      return "Fri";
     case Weekday.Saturday:
-      return "Saturday";
+      return "Sat";
     default:
       return "Unknown";
   }

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,12 @@
   * {
     @apply dark:text-white text-black
   }
+  button {
+    @apply focus:outline-none;
+  }
+  a {
+    @apply outline-none;
+  }
 }
 
 :root {

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -12,3 +12,8 @@ export const authUser = async (code: string): Promise<string | null> => {
     return null;
   }
 };
+
+export const getFriends = async (uid: string) => {
+  const response = await axios.get(`${baseUrl}/friends`, { params: { uid } });
+  return response.data;
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -38,3 +38,8 @@ export const loadingState = atom<boolean>({
   key: "loadingState",
   default: false,
 });
+
+export const weekState = atom<number>({
+  key: "weekState",
+  default: moment().week(),
+})

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -20,7 +20,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { useKeyPress } from "../hooks/useKeyPress";
 import IconButton from "../components/IconButton";
-import { authUser } from "../services/auth";
+import { authUser, getFriends } from "../services/auth";
 import { ColorRing } from "react-loader-spinner";
 import DayOfWeekList from "../components/agenda-page/DayOfWeekList";
 import WeekSwitcher from "../components/agenda-page/WeekSwitcher";
@@ -108,10 +108,17 @@ const Dashboard = () => {
   if (userState) {
     for (let i = 0; i < 7; i++) {
       dayOfWeekComponentsList.push(
-        <DayOfWeekList dayOfWeek={i} key={i} uid={userState!.authUID} />
+        <DayOfWeekList dayOfWeek={i} key={i} uid={userState.authUID} />
       );
     }
   }
+
+  React.useEffect(() => {
+    if (userState != null) {
+      const friends = getFriends(userState.authUID);
+      console.log(friends);
+    }
+  }, [userState])
 
   const clearCreating = () => {
     setNewTaskContent("");

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -23,6 +23,7 @@ import IconButton from "../components/IconButton";
 import { authUser } from "../services/auth";
 import { ColorRing } from "react-loader-spinner";
 import DayOfWeekList from "../components/agenda-page/DayOfWeekList";
+import WeekSwitcher from "../components/agenda-page/WeekSwitcher";
 
 let didInit = false;
 
@@ -125,7 +126,7 @@ const Dashboard = () => {
     <div className="h-full bg-zinc-100 dark:bg-zinc-800 rounded py-2 px-1 w-full flex flex-col">
       {!loading ? (
         <>
-          <div className="flex gap-3 items-center mb-3">
+          <div className="flex gap-3 items-center mb-3 justify-between">
             {!creatingItem ? (
               <div
                 className="flex gap-2 bg-zinc-300 dark:bg-zinc-700 cursor-pointer p-1.5 rounded shadow ml-2 items-center"
@@ -170,6 +171,8 @@ const Dashboard = () => {
                 <IconButton icon={faCircleXmark} onClick={clearCreating} />
               </div>
             )}
+            <WeekSwitcher />
+            <div className="w-[107.406px]"></div> 
           </div>
           <div className="flex flex-1">{dayOfWeekComponentsList}</div>
         </>

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -113,13 +113,6 @@ const Dashboard = () => {
     }
   }
 
-  React.useEffect(() => {
-    if (userState != null) {
-      const friends = getFriends(userState.authUID);
-      console.log(friends);
-    }
-  }, [userState])
-
   const clearCreating = () => {
     setNewTaskContent("");
     setNewTaskDOW(0);


### PR DESCRIPTION
## Week switcher
- Added a week switching component displayed in middle/top of dashboard
- Added `weekState` to atomic store, storing the week# of the year the user has selected, defaulting on page load to today's week
- Adjusted `DayOfWeekList` component to only display tasks matching the currently selected week