### PR TITLE
WD-48: Modals!

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
       #root {
         height: 100%;
         width: 100%;
+        display: flex;
       }
     </style>
     <title>Wenda</title>

--- a/src/components/AddTaskModal.tsx
+++ b/src/components/AddTaskModal.tsx
@@ -2,7 +2,14 @@ import * as React from "react";
 import Modal from "./Modal";
 import moment, { Moment } from "moment";
 import Field, { SelectField } from "./Field";
-import { AddTaskArgs, DayTasks, Task, TaskStatus, getTaskStatusString } from "../schema/Task";
+import {
+  AddTaskArgs,
+  DayTasks,
+  Task,
+  TaskStatus,
+  getTaskStatusFromString,
+  getTaskStatusString,
+} from "../schema/Task";
 import { mapEnum } from "../domain/codeUtils";
 import { getTasksByDate } from "../domain/TaskUtils";
 import { addTask } from "../services/tasks";
@@ -30,7 +37,7 @@ const AddTaskModal: React.FC<AddTaskModalProps> = ({ onClose, onSubmit }) => {
     const timedTaskDate = newTaskDate.set({ hour: 8, minute: 0 });
     const newTask: Partial<Task> = {
       content: newTaskContent,
-      taskStatus: TaskStatus.ToDo,
+      taskStatus: newTaskStatus,
       taskDate: timedTaskDate,
     };
     const addArgs: AddTaskArgs = {
@@ -48,12 +55,18 @@ const AddTaskModal: React.FC<AddTaskModalProps> = ({ onClose, onSubmit }) => {
       setTasks(newDayTasks);
     }
     onSubmit();
-  }, [newTaskContent, newTaskDate, tasks, userState, onSubmit]);
+  }, [newTaskContent, newTaskDate, tasks, userState, onSubmit, newTaskStatus]);
 
   const validSubmit = React.useMemo(() => newTaskContent !== "", [newTaskContent]);
 
   return (
-    <Modal title="Add a task" onClose={onClose} onClickPrimary={submitTask} height="h-40" primaryClickDisabled={!validSubmit}>
+    <Modal
+      title="Add a task"
+      onClose={onClose}
+      onClickPrimary={submitTask}
+      height="h-40"
+      primaryClickDisabled={!validSubmit}
+    >
       <div className="flex flex-col gap-2">
         <Field
           type="text"
@@ -72,7 +85,7 @@ const AddTaskModal: React.FC<AddTaskModalProps> = ({ onClose, onSubmit }) => {
         <SelectField
           label="Task Status:"
           value={getTaskStatusString(newTaskStatus)}
-          onChange={(e) => setNewTaskStatus(+e.target.value as TaskStatus)}
+          onChange={(e) => setNewTaskStatus(getTaskStatusFromString(e.target.value))}
           options={taskStatusStrings}
         />
       </div>

--- a/src/components/AddTaskModal.tsx
+++ b/src/components/AddTaskModal.tsx
@@ -1,7 +1,7 @@
 import Modal from "./Modal";
 
 const AddTaskModal = () => {
-  return <Modal>
+  return <Modal title="Add a task">
     Adding a task!
   </Modal>
 }

--- a/src/components/AddTaskModal.tsx
+++ b/src/components/AddTaskModal.tsx
@@ -26,7 +26,7 @@ const AddTaskModal: React.FC<AddTaskModalProps> = ({ onClose, onSubmit }) => {
     getTaskStatusString(status)
   );
 
-  const submitTask = async () => {
+  const submitTask = React.useCallback(async () => {
     const timedTaskDate = newTaskDate.set({ hour: 8, minute: 0 });
     const newTask: Partial<Task> = {
       content: newTaskContent,
@@ -48,10 +48,12 @@ const AddTaskModal: React.FC<AddTaskModalProps> = ({ onClose, onSubmit }) => {
       setTasks(newDayTasks);
     }
     onSubmit();
-  };
+  }, [newTaskContent, newTaskDate, tasks, userState, onSubmit]);
+
+  const validSubmit = React.useMemo(() => newTaskContent !== "", [newTaskContent]);
 
   return (
-    <Modal title="Add a task" onClose={onClose} onClickPrimary={submitTask} height="h-40">
+    <Modal title="Add a task" onClose={onClose} onClickPrimary={submitTask} height="h-40" primaryClickDisabled={!validSubmit}>
       <div className="flex flex-col gap-2">
         <Field
           type="text"

--- a/src/components/AddTaskModal.tsx
+++ b/src/components/AddTaskModal.tsx
@@ -1,14 +1,79 @@
+import * as React from "react";
 import Modal from "./Modal";
+import moment, { Moment } from "moment";
+import Field, { SelectField } from "./Field";
+import { AddTaskArgs, DayTasks, Task, TaskStatus, getTaskStatusString } from "../schema/Task";
+import { mapEnum } from "../domain/codeUtils";
+import { getTasksByDate } from "../domain/TaskUtils";
+import { addTask } from "../services/tasks";
+import { useRecoilState, useRecoilValue } from "recoil";
+import { authUserState, tasksState } from "../store";
 
 type AddTaskModalProps = {
   onClose: () => void;
-  onSubmit?: () => void;
+  onSubmit: () => void;
 };
 
+const CONTENT_PLACEHOLDER = "New task content...";
+
 const AddTaskModal: React.FC<AddTaskModalProps> = ({ onClose, onSubmit }) => {
+  const [tasks, setTasks] = useRecoilState(tasksState);
+  const userState = useRecoilValue(authUserState);
+  const [newTaskContent, setNewTaskContent] = React.useState<string>("");
+  const [newTaskDate, setNewTaskDate] = React.useState<Moment>(moment());
+  const [newTaskStatus, setNewTaskStatus] = React.useState<TaskStatus>(TaskStatus.ToDo);
+  const taskStatusStrings = mapEnum(TaskStatus, (status: TaskStatus) =>
+    getTaskStatusString(status)
+  );
+
+  const submitTask = async () => {
+    const timedTaskDate = newTaskDate.set({ hour: 8, minute: 0 });
+    const newTask: Partial<Task> = {
+      content: newTaskContent,
+      taskStatus: TaskStatus.ToDo,
+      taskDate: timedTaskDate,
+    };
+    const addArgs: AddTaskArgs = {
+      uid: userState!.authUID,
+      taskData: newTask,
+    };
+    const newTaskRes = await addTask(addArgs);
+    if (newTaskRes) {
+      const newDayTasks: DayTasks = {
+        ...tasks,
+        [newTaskRes.taskDate.format("YYYY-MM-DD")]: {
+          tasks: [...getTasksByDate(tasks, newTaskDate), newTaskRes],
+        },
+      };
+      setTasks(newDayTasks);
+    }
+    onSubmit();
+  };
+
   return (
-    <Modal title="Add a task" onClose={onClose} onClickPrimary={onSubmit}>
-      Adding a task!
+    <Modal title="Add a task" onClose={onClose} onClickPrimary={submitTask} height="h-40">
+      <div className="flex flex-col gap-2">
+        <Field
+          type="text"
+          label="Task Content:"
+          value={newTaskContent}
+          onChange={(e) => setNewTaskContent(e.target.value)}
+          placeholder={CONTENT_PLACEHOLDER}
+          autoFocus
+        />
+        <Field
+          type="date"
+          label="Task Date:"
+          value={newTaskDate.format("YYYY-MM-DD")}
+          onChange={(e) => setNewTaskDate(moment(e.target.value))}
+        />
+        <SelectField
+          label="Task Status:"
+          value={getTaskStatusString(newTaskStatus)}
+          onChange={(e) => setNewTaskStatus(+e.target.value as TaskStatus)}
+          options={taskStatusStrings}
+        />
+      </div>
     </Modal>
   );
 };

--- a/src/components/AddTaskModal.tsx
+++ b/src/components/AddTaskModal.tsx
@@ -1,9 +1,16 @@
 import Modal from "./Modal";
 
-const AddTaskModal = () => {
-  return <Modal title="Add a task">
-    Adding a task!
-  </Modal>
-}
+type AddTaskModalProps = {
+  onClose: () => void;
+  onSubmit?: () => void;
+};
+
+const AddTaskModal: React.FC<AddTaskModalProps> = ({ onClose, onSubmit }) => {
+  return (
+    <Modal title="Add a task" onClose={onClose} onClickPrimary={onSubmit}>
+      Adding a task!
+    </Modal>
+  );
+};
 
 export default AddTaskModal;

--- a/src/components/AddTaskModal.tsx
+++ b/src/components/AddTaskModal.tsx
@@ -1,0 +1,9 @@
+import Modal from "./Modal";
+
+const AddTaskModal = () => {
+  return <Modal>
+    Adding a task!
+  </Modal>
+}
+
+export default AddTaskModal;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+
+export enum ButtonType {
+  Primary = "primary",
+  Secondary = "secondary",
+  Danger = "danger",
+  Warning = "warning",
+  Success = "success",
+  Info = "info",
+}
+
+type ButtonProps = React.PropsWithChildren & {
+  disabled?: boolean;
+  onClick?: () => void;
+  className?: string;
+  type?: ButtonType;
+  size?: "sm" | "md" | "lg";
+};
+
+const Button: React.FC<ButtonProps> = ({ disabled, onClick, className, type, size, children }) => {
+  const buttonClassName = `px-2 py-1 rounded-md ${className} ${
+    type === ButtonType.Primary
+      ? "bg-disc-blue text-white"
+      : type === ButtonType.Secondary
+      ? "bg-disc-blue/20 text-disc-blue"
+      : type === ButtonType.Danger
+      ? "bg-red-450 text-white"
+      : type === ButtonType.Warning
+      ? "bg-yellow-500 text-white"
+      : type === ButtonType.Success
+      ? "bg-green-500 text-white"
+      : type === ButtonType.Info
+      ? "bg-blue-500 text-white"
+      : "bg-disc-blue text-white"
+  } ${size === "sm" ? "text-sm" : size === "lg" ? "text-lg" : "text-md"}`;
+
+  return (
+    <button disabled={disabled} onClick={onClick} className={buttonClassName}>
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,8 +1,6 @@
 import { IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as React from "react";
-import { useRecoilValue } from "recoil";
-import { themeState } from "../store";
 
 export enum ButtonType {
   Primary = "primary",
@@ -35,7 +33,6 @@ const Button: React.FC<ButtonProps> = ({
   iconPosition,
   notEnterable,
 }) => {
-  const theme = useRecoilValue(themeState);
 
   const buttonClassName = `px-2 py-1 rounded-md ${className} ${
     type === ButtonType.Primary
@@ -55,9 +52,9 @@ const Button: React.FC<ButtonProps> = ({
     size === "xs" ? "text-xs" : size === "sm" ? "text-sm" : size === "lg" ? "text-lg" : "text-md"
   }`;
 
-  const contentClassName = `flex items-center justify-center gap-2 ${
+  const contentClassName = `flex items-center justify-center gap-2 text-inherit ${
     icon && iconPosition === "right" ? "flex-row-reverse" : "flex-row"
-  } ${theme ? "text-white" : "text-black"}`;
+  }`;
 
   return (
     <button
@@ -75,7 +72,7 @@ const Button: React.FC<ButtonProps> = ({
       }
     >
       <div className={contentClassName}>
-        {icon && <FontAwesomeIcon icon={icon} />}
+        {icon && <FontAwesomeIcon icon={icon}/>}
         {children}
       </div>
     </button>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -33,28 +33,52 @@ const Button: React.FC<ButtonProps> = ({
   iconPosition,
   notEnterable,
 }) => {
+  const getTypeText = React.useCallback(() => {
+    switch (type) {
+      case ButtonType.Primary:
+        return "bg-disc-blue text-white";
+      case ButtonType.Secondary:
+        return "bg-disc-blue/20 text-disc-blue";
+      case ButtonType.Danger:
+        return "bg-red-450 text-white";
+      case ButtonType.Warning:
+        return "bg-yellow-500 text-white";
+      case ButtonType.Success:
+        return "bg-green-500 text-white";
+      case ButtonType.Info:
+        return "bg-blue-500 text-white";
+      default:
+        return "bg-disc-blue text-white";
+    }
+  }, [type]);
 
-  const buttonClassName = React.useMemo(() => `px-2 py-1 rounded-md ${className} ${
-    type === ButtonType.Primary
-      ? "bg-disc-blue text-white"
-      : type === ButtonType.Secondary
-      ? "bg-disc-blue/20 text-disc-blue"
-      : type === ButtonType.Danger
-      ? "bg-red-450 text-white"
-      : type === ButtonType.Warning
-      ? "bg-yellow-500 text-white"
-      : type === ButtonType.Success
-      ? "bg-green-500 text-white"
-      : type === ButtonType.Info
-      ? "bg-blue-500 text-white"
-      : "bg-disc-blue text-white"
-  } ${
-    size === "xs" ? "text-xs" : size === "sm" ? "text-sm" : size === "lg" ? "text-lg" : "text-md"
-  } ${disabled ? "opacity-50 " : "hover:opacity-80"}`, [className, disabled, size, type]);
+  const getSizeText = React.useCallback(() => {
+    switch (size) {
+      case "xs":
+        return "text-xs";
+      case "sm":
+        return "text-sm";
+      case "lg":
+        return "text-lg";
+      default:
+        return "text-md";
+    }
+  }, [size]);
 
-  const contentClassName = React.useMemo(() => `flex items-center justify-center gap-2 text-inherit ${
-    icon && iconPosition === "right" ? "flex-row-reverse" : "flex-row"
-  }`, [icon, iconPosition]);
+  const buttonClassName = React.useMemo(
+    () => `px-2 py-1 rounded-md ${className} 
+    ${getTypeText()} ${getSizeText()} 
+    ${disabled ? "opacity-50 " : "hover:opacity-80"}`,
+    [className, disabled, size, type]
+  );
+
+  const contentClassName = React.useMemo(
+    () =>
+      `flex items-center justify-center gap-2 text-inherit ${
+        icon && iconPosition === "right" ? "flex-row-reverse" : "flex-row"
+      }`,
+    [icon, iconPosition]
+  );
 
   return (
     <button
@@ -72,7 +96,7 @@ const Button: React.FC<ButtonProps> = ({
       }
     >
       <div className={contentClassName}>
-        {icon && <FontAwesomeIcon icon={icon}/>}
+        {icon && <FontAwesomeIcon icon={icon} />}
         {children}
       </div>
     </button>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -34,7 +34,7 @@ const Button: React.FC<ButtonProps> = ({
   notEnterable,
 }) => {
 
-  const buttonClassName = `px-2 py-1 rounded-md ${className} ${
+  const buttonClassName = React.useMemo(() => `px-2 py-1 rounded-md ${className} ${
     type === ButtonType.Primary
       ? "bg-disc-blue text-white"
       : type === ButtonType.Secondary
@@ -50,11 +50,11 @@ const Button: React.FC<ButtonProps> = ({
       : "bg-disc-blue text-white"
   } ${
     size === "xs" ? "text-xs" : size === "sm" ? "text-sm" : size === "lg" ? "text-lg" : "text-md"
-  }`;
+  } ${disabled ? "opacity-50 " : "hover:opacity-80"}`, [className, disabled, size, type]);
 
-  const contentClassName = `flex items-center justify-center gap-2 text-inherit ${
+  const contentClassName = React.useMemo(() => `flex items-center justify-center gap-2 text-inherit ${
     icon && iconPosition === "right" ? "flex-row-reverse" : "flex-row"
-  }`;
+  }`, [icon, iconPosition]);
 
   return (
     <button

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -14,7 +14,7 @@ type ButtonProps = React.PropsWithChildren & {
   onClick?: () => void;
   className?: string;
   type?: ButtonType;
-  size?: "sm" | "md" | "lg";
+  size?: "xs" | "sm" | "md" | "lg";
 };
 
 const Button: React.FC<ButtonProps> = ({ disabled, onClick, className, type, size, children }) => {
@@ -32,7 +32,9 @@ const Button: React.FC<ButtonProps> = ({ disabled, onClick, className, type, siz
       : type === ButtonType.Info
       ? "bg-blue-500 text-white"
       : "bg-disc-blue text-white"
-  } ${size === "sm" ? "text-sm" : size === "lg" ? "text-lg" : "text-md"}`;
+  } ${
+    size === "xs" ? "text-xs" : size === "sm" ? "text-sm" : size === "lg" ? "text-lg" : "text-md"
+  }`;
 
   return (
     <button disabled={disabled} onClick={onClick} className={buttonClassName}>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,4 +1,8 @@
+import { IconDefinition } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as React from "react";
+import { useRecoilValue } from "recoil";
+import { themeState } from "../store";
 
 export enum ButtonType {
   Primary = "primary",
@@ -15,9 +19,24 @@ type ButtonProps = React.PropsWithChildren & {
   className?: string;
   type?: ButtonType;
   size?: "xs" | "sm" | "md" | "lg";
+  icon?: IconDefinition;
+  iconPosition?: "left" | "right";
+  notEnterable?: boolean;
 };
 
-const Button: React.FC<ButtonProps> = ({ disabled, onClick, className, type, size, children }) => {
+const Button: React.FC<ButtonProps> = ({
+  disabled,
+  onClick,
+  className,
+  type,
+  size,
+  children,
+  icon,
+  iconPosition,
+  notEnterable,
+}) => {
+  const theme = useRecoilValue(themeState);
+
   const buttonClassName = `px-2 py-1 rounded-md ${className} ${
     type === ButtonType.Primary
       ? "bg-disc-blue text-white"
@@ -36,9 +55,29 @@ const Button: React.FC<ButtonProps> = ({ disabled, onClick, className, type, siz
     size === "xs" ? "text-xs" : size === "sm" ? "text-sm" : size === "lg" ? "text-lg" : "text-md"
   }`;
 
+  const contentClassName = `flex items-center justify-center gap-2 ${
+    icon && iconPosition === "right" ? "flex-row-reverse" : "flex-row"
+  } ${theme ? "text-white" : "text-black"}`;
+
   return (
-    <button disabled={disabled} onClick={onClick} className={buttonClassName}>
-      {children}
+    <button
+      disabled={disabled}
+      onClick={onClick}
+      className={buttonClassName}
+      onKeyDown={
+        !notEnterable && onClick
+          ? (e) => {
+              if (e.key === "Enter") {
+                onClick();
+              }
+            }
+          : undefined
+      }
+    >
+      <div className={contentClassName}>
+        {icon && <FontAwesomeIcon icon={icon} />}
+        {children}
+      </div>
     </button>
   );
 };

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+
+type FieldProps = {
+  label: string;
+  value: string;
+  type: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  stacked?: boolean;
+  autoFocus?: boolean;
+  placeholder?: string;
+}
+
+type SelectFieldProps = Omit<FieldProps, 'type' | 'onChange'> & {
+  options: string[];
+  onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+}
+
+export const SelectField: React.FC<SelectFieldProps> = ({
+  label,
+  value,
+  onChange,
+  stacked,
+  autoFocus,
+  placeholder,
+  options
+}) => {
+  return (
+    <div className={`flex ${stacked ? 'flex-col gap-1' : 'flex-row items-center gap-3'}`}>
+      <label className="font-semibold">{label}</label>
+      <select
+        value={value}
+        onChange={onChange}
+        className="rounded p-1 dark:bg-zinc-700 bg-gray-200 flex-1"
+        autoFocus={autoFocus}
+        placeholder={placeholder}
+      >
+        {options.map((option) => (
+          <option key={option} value={option}>{option}</option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+const Field: React.FC<FieldProps> = ({
+  label,
+  value,
+  type,
+  onChange,
+  stacked,
+  autoFocus,
+  placeholder
+}) => {
+  return (
+    <div className={`flex ${stacked ? 'flex-col gap-1' : 'flex-row items-center gap-3'}`}>
+      <label className="font-semibold">{label}</label>
+      <input
+        type={type}
+        value={value}
+        onChange={onChange}
+        className="rounded p-1 dark:bg-zinc-700 bg-gray-200 flex-1"
+        autoFocus={autoFocus}
+        placeholder={placeholder}
+      />
+    </div>
+  )
+}
+
+export default Field;

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
@@ -22,20 +23,15 @@ interface IconButtonProps {
     | "9xl";
 }
 
-const IconButton: React.FC<IconButtonProps> = ({
-  icon,
-  onClick,
-  className,
-  size,
-  disabled,
-}) => {
-  const baseClassName =
-    "cursor-pointer " +
-    (disabled ? `opacity-40` : "") +
-    (className ? ` ${className}` : "");
-  const computedClassName = size
-    ? `text-${size} ${baseClassName}`
-    : `${baseClassName}`;
+const IconButton: React.FC<IconButtonProps> = ({ icon, onClick, className, size, disabled }) => {
+  const baseClassName = React.useMemo(
+    () => "cursor-pointer " + (disabled ? `opacity-40` : "") + (className ? ` ${className}` : ""),
+    [className, disabled, size]
+  );
+  const computedClassName = React.useMemo(
+    () => (size ? `text-${size} ${baseClassName}` : `${baseClassName}`),
+    [baseClassName, size]
+  );
 
   return (
     <FontAwesomeIcon
@@ -44,9 +40,7 @@ const IconButton: React.FC<IconButtonProps> = ({
       onClick={onClick}
       role="button"
       tabIndex={0}
-      onKeyDown={
-        onClick != null ? (e) => e.key === "Enter" && onClick() : undefined
-      }
+      onKeyDown={onClick != null ? (e) => e.key === "Enter" && onClick() : undefined}
     />
   );
 };

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -25,7 +25,7 @@ interface IconButtonProps {
 
 const IconButton: React.FC<IconButtonProps> = ({ icon, onClick, className, size, disabled }) => {
   const baseClassName = React.useMemo(
-    () => "cursor-pointer " + (disabled ? `opacity-40` : "") + (className ? ` ${className}` : ""),
+    () => `cursor-pointer ${disabled ? `opacity-40` : ""} ${className}`,
     [className, disabled, size]
   );
   const computedClassName = React.useMemo(

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { createPortal } from "react-dom";
+import { useRecoilValue } from "recoil";
+import { themeState } from "../store";
+import { motion } from "framer-motion";
+
+type ModalProps = React.PropsWithChildren & {
+  onClose?: () => void;
+  containerClassName?: string;
+  height?: string;
+  width?: string;
+};
+
+const Modal: React.FC<ModalProps> = ({ children, containerClassName, height, width }) => {
+  const theme = useRecoilValue(themeState);
+
+  const modalPageClassName = `fixed flex items-center justify-center inset-0 overflow-hidden ${
+    theme ? "bg-zinc-800/60" : "bg-zinc-400/60"
+  }`;
+
+  const defaultContainerBackgroundColor = theme ? "bg-zinc-800" : "bg-white";
+  const defaultContainerFontColor = theme ? "text-white" : "text-black";
+
+  const modalContainerClassName = `fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-lg shadow p-4
+    ${defaultContainerFontColor}
+    ${containerClassName || defaultContainerBackgroundColor} 
+    ${height || "h-96"} ${width || "w-96"}`;
+
+  const modalJSX = (
+    <div className={modalPageClassName}>
+      <motion.div animate={{ opacity: [0, 1] }} transition={{ duration: 0.25 }} className={modalContainerClassName}>
+        {children}
+      </motion.div>
+    </div>
+  );
+
+  return createPortal(modalJSX, document.querySelector("#root") as HTMLElement);
+};
+
+export default Modal;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -5,31 +5,55 @@ import { themeState } from "../store";
 import { motion } from "framer-motion";
 
 type ModalProps = React.PropsWithChildren & {
+  title: string;
   onClose?: () => void;
   containerClassName?: string;
+  headerClassName?: string;
   height?: string;
   width?: string;
 };
 
-const Modal: React.FC<ModalProps> = ({ children, containerClassName, height, width }) => {
+const Modal: React.FC<ModalProps> = ({
+  children,
+  title,
+  containerClassName,
+  headerClassName,
+  height,
+  width,
+}) => {
   const theme = useRecoilValue(themeState);
+  const defaultFontColor = theme ? "text-white" : "text-black";
+  const defaultModalHeaderBackgroundColor = theme ? "bg-zinc-700" : "bg-zinc-200";
+  const defaultBodyBackgroundColor = theme ? "bg-zinc-800" : "bg-white";
 
   const modalPageClassName = `fixed flex items-center justify-center inset-0 overflow-hidden ${
     theme ? "bg-zinc-800/60" : "bg-zinc-400/60"
   }`;
 
-  const defaultContainerBackgroundColor = theme ? "bg-zinc-800" : "bg-white";
-  const defaultContainerFontColor = theme ? "text-white" : "text-black";
+  const modalContainerClassName = `fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col shadow-lg`;
 
-  const modalContainerClassName = `fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-lg shadow p-4
-    ${defaultContainerFontColor}
-    ${containerClassName || defaultContainerBackgroundColor} 
-    ${height || "h-96"} ${width || "w-96"}`;
+  const modalHeaderClassName = `text-lg font-semibold rounded-t-lg p-2
+  ${defaultModalHeaderBackgroundColor} ${defaultFontColor} ${headerClassName}`;
+
+  const modalBodyClassName = `p-2 ${defaultFontColor} ${height || "h-[30em]"} 
+  ${width || "w-[25em]"} ${defaultBodyBackgroundColor} ${containerClassName}`;
+
+  const modalFooterClassName = `rounded-b-lg p-2 ${defaultModalHeaderBackgroundColor} ${defaultFontColor} min-h-[3em]`
 
   const modalJSX = (
     <div className={modalPageClassName}>
-      <motion.div animate={{ opacity: [0, 1] }} transition={{ duration: 0.25 }} className={modalContainerClassName}>
-        {children}
+      {/* modal container */}
+      <motion.div
+        className={modalContainerClassName}
+        animate={{ opacity: [0, 1] }}
+        transition={{ duration: 0.25 }}
+      >
+        {/* modal header */}
+        <div className={modalHeaderClassName}>{title}</div>
+        {/* modal body */}
+        <div className={modalBodyClassName}>{children}</div>
+        {/* modal footer */}
+        <div className={modalFooterClassName}></div>
       </motion.div>
     </div>
   );

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -40,8 +40,9 @@ const Modal: React.FC<ModalProps> = ({
   const defaultFontColor = theme ? "text-white" : "text-black";
   const defaultModalHeaderBackgroundColor = theme ? "bg-zinc-700" : "bg-zinc-200";
   const defaultBodyBackgroundColor = theme ? "bg-zinc-800" : "bg-white";
+  const defaultPageTheme = theme ? "dark" : "light";
 
-  const modalPageClassName = `fixed flex items-center justify-center inset-0 overflow-hidden ${
+  const modalPageClassName = `fixed flex items-center justify-center inset-0 overflow-hidden ${defaultPageTheme} ${
     theme ? "bg-zinc-800/70" : "bg-zinc-400/60"
   }`;
 
@@ -50,7 +51,7 @@ const Modal: React.FC<ModalProps> = ({
   const modalHeaderClassName = `text-lg font-semibold rounded-t-lg p-2
   ${defaultModalHeaderBackgroundColor} ${defaultFontColor} ${headerClassName}`;
 
-  const modalBodyClassName = `p-2 ${defaultFontColor} ${height || "h-[30em]"} 
+  const modalBodyClassName = `p-4 ${defaultFontColor} ${height || "h-[30em]"} 
   ${width || "w-[25em]"} ${defaultBodyBackgroundColor} ${containerClassName}`;
 
   const modalFooterClassName = `rounded-b-lg p-2 min-h-[2.5em] flex gap-1 justify-end ${defaultModalHeaderBackgroundColor} ${defaultFontColor}`;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -4,7 +4,7 @@ import { useRecoilValue } from "recoil";
 import { themeState } from "../store";
 import { motion } from "framer-motion";
 import Button, { ButtonType } from "./Button";
-import { faCancel } from "@fortawesome/free-solid-svg-icons";
+import { useKeyPress } from "../hooks/useKeyPress";
 
 type ModalProps = React.PropsWithChildren & {
   title: string;
@@ -55,6 +55,16 @@ const Modal: React.FC<ModalProps> = ({
   ${width || "w-[25em]"} ${defaultBodyBackgroundColor} ${containerClassName}`;
 
   const modalFooterClassName = `rounded-b-lg p-2 min-h-[2.5em] flex gap-1 justify-end ${defaultModalHeaderBackgroundColor} ${defaultFontColor}`;
+
+  const enterAction = React.useMemo(() => {
+    if (onClickPrimary != undefined && !primaryClickDisabled) {
+      return onClickPrimary;
+    }
+    return () => null;
+  }, [onClickPrimary, primaryClickDisabled]);
+
+  useKeyPress(["Enter"], enterAction);
+  useKeyPress(["Escape"], onClose);
 
   const modalJSX = (
     <div className={modalPageClassName}>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -3,10 +3,17 @@ import { createPortal } from "react-dom";
 import { useRecoilValue } from "recoil";
 import { themeState } from "../store";
 import { motion } from "framer-motion";
+import Button, { ButtonType } from "./Button";
 
 type ModalProps = React.PropsWithChildren & {
   title: string;
-  onClose?: () => void;
+  onClose: () => void;
+  onClickPrimary?: () => void;
+  onClickSecondary?: () => void;
+  primaryClickDisabled?: boolean;
+  secondaryClickDisabled?: boolean;
+  primaryClickText?: string;
+  secondaryClickText?: string;
   containerClassName?: string;
   headerClassName?: string;
   height?: string;
@@ -16,6 +23,13 @@ type ModalProps = React.PropsWithChildren & {
 const Modal: React.FC<ModalProps> = ({
   children,
   title,
+  onClose,
+  onClickPrimary,
+  primaryClickDisabled,
+  primaryClickText,
+  onClickSecondary,
+  secondaryClickDisabled,
+  secondaryClickText,
   containerClassName,
   headerClassName,
   height,
@@ -27,7 +41,7 @@ const Modal: React.FC<ModalProps> = ({
   const defaultBodyBackgroundColor = theme ? "bg-zinc-800" : "bg-white";
 
   const modalPageClassName = `fixed flex items-center justify-center inset-0 overflow-hidden ${
-    theme ? "bg-zinc-800/60" : "bg-zinc-400/60"
+    theme ? "bg-zinc-800/70" : "bg-zinc-400/60"
   }`;
 
   const modalContainerClassName = `fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col shadow-lg`;
@@ -38,7 +52,7 @@ const Modal: React.FC<ModalProps> = ({
   const modalBodyClassName = `p-2 ${defaultFontColor} ${height || "h-[30em]"} 
   ${width || "w-[25em]"} ${defaultBodyBackgroundColor} ${containerClassName}`;
 
-  const modalFooterClassName = `rounded-b-lg p-2 ${defaultModalHeaderBackgroundColor} ${defaultFontColor} min-h-[3em]`
+  const modalFooterClassName = `rounded-b-lg p-2 min-h-[2.5em] flex gap-1 justify-end ${defaultModalHeaderBackgroundColor} ${defaultFontColor}`;
 
   const modalJSX = (
     <div className={modalPageClassName}>
@@ -53,7 +67,21 @@ const Modal: React.FC<ModalProps> = ({
         {/* modal body */}
         <div className={modalBodyClassName}>{children}</div>
         {/* modal footer */}
-        <div className={modalFooterClassName}></div>
+        <div className={modalFooterClassName}>
+          {onClickPrimary && (
+            <Button onClick={onClickPrimary} disabled={primaryClickDisabled} size="sm">
+              {primaryClickText || "Confirm"}
+            </Button>
+          )}
+          <Button
+            onClick={onClickSecondary || onClose}
+            disabled={secondaryClickDisabled}
+            type={ButtonType.Danger}
+            size="sm"
+          >
+            {secondaryClickText || "Cancel"}
+          </Button>
+        </div>
       </motion.div>
     </div>
   );

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -4,6 +4,7 @@ import { useRecoilValue } from "recoil";
 import { themeState } from "../store";
 import { motion } from "framer-motion";
 import Button, { ButtonType } from "./Button";
+import { faCancel } from "@fortawesome/free-solid-svg-icons";
 
 type ModalProps = React.PropsWithChildren & {
   title: string;

--- a/src/components/agenda-page/CreateItemButton.tsx
+++ b/src/components/agenda-page/CreateItemButton.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import Button from '../Button';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
+
+type CreateItemButtonProps = {
+  createItemAction: () => void;
+}
+
+const CreateItemButton: React.FC<CreateItemButtonProps> = ({ createItemAction }) => {
+  return (
+    <Button
+      icon={faPlus}
+      onClick={createItemAction}
+    >
+      Create item
+    </Button>
+  )
+}
+
+export default CreateItemButton;

--- a/src/components/agenda-page/DayOfWeekList.tsx
+++ b/src/components/agenda-page/DayOfWeekList.tsx
@@ -40,7 +40,7 @@ const DayOfWeekList: React.FC<DayOfWeekListProps> = ({ dayOfWeek, uid }) => {
 
   const contClassName = React.useMemo(
     () =>
-      `group w-full mr-1 first:ml-1 last:border-r-0 dark:border-x-neutral-500 bg-gray-200 dark:bg-zinc-700 ${
+      `group w-full bg-gray-200 dark:bg-zinc-700 ${
         isToday && "border-t-4 border-t-disc-blue"
       }`,
     [isToday]

--- a/src/components/agenda-page/NewTaskForm.tsx
+++ b/src/components/agenda-page/NewTaskForm.tsx
@@ -63,7 +63,7 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
       <div className="rounded-t bg-slate-50 dark:bg-zinc-800 p-2 min-h-20 shadow">
         <input
           value={newContent}
-          className="pl-1 rounded dark:bg-zinc-700 bg-white"
+          className="pl-1 rounded dark:bg-zinc-700 bg-white w-full"
           onChange={(e) => setNewContent(e.target.value)}
           autoFocus
         />

--- a/src/components/agenda-page/TaskItem.tsx
+++ b/src/components/agenda-page/TaskItem.tsx
@@ -18,7 +18,7 @@ interface TaskItemProps {
 
 const CONTENT_DIV_BASE_CLASSNAME =
   "bg-slate-50 dark:bg-zinc-800 p-2 min-h-20 shadow rounded mb-1 mx-1";
-const CONTENT_TEXT_BASE_CLASSNAME = "w-fit cursor-pointer";
+const CONTENT_TEXT_BASE_CLASSNAME = "w-fit cursor-pointer overflow-hidden text-ellipsis";
 
 const TaskItem: React.FC<TaskItemProps> = ({ task, uid, index }) => {
   const [dayTasks, setDayTasks] = useRecoilState(tasksState);
@@ -125,7 +125,7 @@ const TaskItem: React.FC<TaskItemProps> = ({ task, uid, index }) => {
               <input
                 onChange={(e) => setNewContent(e.target.value)}
                 value={newContent}
-                className="pl-1 rounded dark:bg-zinc-700 bg-white"
+                className="pl-1 rounded dark:bg-zinc-700 bg-white w-11/12"
                 autoFocus
               />
               <IconButton icon={faCheckCircle} onClick={handleEdit} size="sm" />

--- a/src/domain/codeUtils.ts
+++ b/src/domain/codeUtils.ts
@@ -1,0 +1,9 @@
+type EnumType = { [s: number]: string };
+
+export function mapEnum(enumerable: EnumType, fn: Function): any[] {
+    let enumMembers: any[] = Object.keys(enumerable).map((key: any) => enumerable[key]);
+
+    let enumValues: number[] = enumMembers.filter(v => typeof v === "number");
+
+    return enumValues.map(m => fn(m));
+}

--- a/src/schema/Task.ts
+++ b/src/schema/Task.ts
@@ -42,6 +42,19 @@ export const getTaskStatusString = (status: TaskStatus) => {
   }
 };
 
+export const getTaskStatusFromString = (status: string) => {
+  switch (status) {
+    case "To Do":
+      return TaskStatus.ToDo;
+    case "Completed":
+      return TaskStatus.Completed;
+    case "Archived":
+      return TaskStatus.Archived;
+    default:
+      return TaskStatus.ToDo;
+  }
+}
+
 export interface Task {
   taskID: string;
   timeCreated: Moment;

--- a/src/schema/Task.ts
+++ b/src/schema/Task.ts
@@ -31,6 +31,17 @@ export enum TaskStatus {
   Archived,
 }
 
+export const getTaskStatusString = (status: TaskStatus) => {
+  switch (status) {
+    case TaskStatus.ToDo:
+      return "To Do";
+    case TaskStatus.Completed:
+      return "Completed";
+    case TaskStatus.Archived:
+      return "Archived";
+  }
+};
+
 export interface Task {
   taskID: string;
   timeCreated: Moment;

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,13 +3,9 @@ import { selector, atom } from "recoil";
 import { DayTasks, Task } from "./schema/Task";
 import { User } from "./schema/User";
 
-const authCookie = document.cookie.replace(
-  /(?:(?:^|.*;\s*)authuid\s*\=\s*([^;]*).*$)|^.*$/,
-  "$1"
-);
+const authCookie = document.cookie.replace(/(?:(?:^|.*;\s*)authuid\s*\=\s*([^;]*).*$)|^.*$/, "$1");
 
-const getDefaultTheme = () =>
-window.matchMedia("(prefers-color-scheme: dark)").matches;
+const getDefaultTheme = () => window.matchMedia("(prefers-color-scheme: dark)").matches;
 
 const getBaseTheme = () => {
   // returns true if dark mode, false if light mode
@@ -44,7 +40,7 @@ export const loadingState = atom<boolean>({
 export const weekState = atom<number>({
   key: "weekState",
   default: moment().week(),
-})
+});
 
 export const themeState = atom<boolean>({
   key: "themeState",
@@ -54,4 +50,4 @@ export const themeState = atom<boolean>({
 export const draggingState = atom<boolean>({
   key: "draggingState",
   default: false,
-})
+});

--- a/src/views/AuthLayout.tsx
+++ b/src/views/AuthLayout.tsx
@@ -56,7 +56,7 @@ const AuthLayout = () => {
             {showUserInfo && <UserMenu user={discordUserRes} />}
           </div>
         </div>
-        <div className="flex dark:text-white mx-5 my-4 flex-1 justify-center">
+        <div className="flex dark:text-white mx-5 mt-4 mb-10 flex-1 justify-center">
           <Outlet />
         </div>
       </div>

--- a/src/views/AuthLayout.tsx
+++ b/src/views/AuthLayout.tsx
@@ -37,8 +37,8 @@ const AuthLayout = () => {
   const showUserInfo = React.useMemo(() => loggedIn && (discordUserRes.id !== ""), [loggedIn, discordUserRes])
 
   return (
-    <div className={isDarkMode ? "dark h-full" : "light h-full"}>
-      <div className="h-full dark:bg-zinc-900 bg-white">
+    <div className={`flex flex-1 ${isDarkMode ? "dark" : "light"}`}>
+      <div className="dark:bg-zinc-900 bg-white flex flex-col flex-1">
         <div className="flex dark:bg-light-gray bg-zinc-300 max-w-none h-20 items-center justify-end">
           <div className="w-[175px]"></div>
         {loggedIn && (
@@ -56,7 +56,7 @@ const AuthLayout = () => {
             {showUserInfo && <UserMenu user={discordUserRes} />}
           </div>
         </div>
-        <div className="flex dark:text-white mx-5 my-2 h-5/6 justify-center">
+        <div className="flex dark:text-white mx-5 my-4 flex-1 justify-center">
           <Outlet />
         </div>
       </div>

--- a/src/views/AuthLayout.tsx
+++ b/src/views/AuthLayout.tsx
@@ -1,11 +1,7 @@
 import React from "react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Outlet } from "react-router-dom";
-import { faMoon, faSun } from "@fortawesome/free-solid-svg-icons";
-import LogoutButton from "../components/LogoutButton";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { authUserState, loggedInState, themeState } from "../store";
-import UserImage from "../components/UserImage";
 import UserTag from "../components/UserTag";
 import UserMenu from "../components/UserMenu";
 import { getUser } from "../services/discord";
@@ -60,7 +56,7 @@ const AuthLayout = () => {
             {showUserInfo && <UserMenu user={discordUserRes} />}
           </div>
         </div>
-        <div className="flex dark:text-white mx-5 my-2 h-5/6">
+        <div className="flex dark:text-white mx-5 my-2 h-5/6 justify-center">
           <Outlet />
         </div>
       </div>

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -190,7 +190,7 @@ const Dashboard = () => {
   useKeyPress(["i"], () => setShowAddModal(true), null, true);
 
   return (
-    <div className="h-full bg-zinc-100 dark:bg-zinc-800 rounded py-2 px-1 flex flex-col mt-4 w-dashboard min-w-[1000px]">
+    <div className="bg-zinc-100 dark:bg-zinc-800 rounded py-2 px-1 flex flex-col w-dashboard min-w-[1000px]">
       {!loading ? (
         <>
           <div className="flex gap-3 items-center mb-3 justify-between ml-1">

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -1,4 +1,4 @@
-import moment, { Moment } from "moment";
+import moment from "moment";
 import React from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useRecoilState, useRecoilValue } from "recoil";
@@ -10,14 +10,9 @@ import {
   tasksState,
   weekState,
 } from "../store";
-import { DayTasks, EditOrderArgs, Task, TaskStatus } from "../schema/Task";
-import { AddTaskArgs } from "../schema/Task";
-import { addTask, editOrder, getTasks } from "../services/tasks";
-import { Weekday } from "../schema/Weekday";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCheckCircle, faCirclePlus, faCircleXmark } from "@fortawesome/free-solid-svg-icons";
+import { DayTasks, EditOrderArgs } from "../schema/Task";
+import { editOrder, getTasks } from "../services/tasks";
 import { useKeyPress } from "../hooks/useKeyPress";
-import IconButton from "../components/IconButton";
 import { authUser } from "../services/auth";
 import { ColorRing } from "react-loader-spinner";
 import DayOfWeekList from "../components/agenda-page/DayOfWeekList";

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -248,7 +248,7 @@ const Dashboard = () => {
   useKeyPress(["i"], () => setCreatingItem(true), null, true);
 
   return (
-    <div className="h-full bg-zinc-100 dark:bg-zinc-800 rounded py-2 px-1 w-full flex flex-col">
+    <div className="h-full bg-zinc-100 dark:bg-zinc-800 rounded py-2 px-1 flex flex-col mt-4 w-4/5">
       {!loading ? (
         <>
           <div className="flex gap-3 items-center mb-3 justify-between">
@@ -301,7 +301,7 @@ const Dashboard = () => {
             <div className="w-[107.406px]"></div>
           </div>
           <DragDropContext onDragEnd={onDragEnd} onDragStart={onDragStart}>
-            <div className="flex flex-1">{dayOfWeekComponentsList}</div>
+            <div className="grid grid-cols-7 gap-1 h-full">{dayOfWeekComponentsList}</div>
           </DragDropContext>
         </>
       ) : (

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -32,6 +32,7 @@ import {
 } from "@hello-pangea/dnd";
 import { getTasksByDate } from "../domain/TaskUtils";
 import { getWeekdayFromDay } from "../domain/WeekdayUtils";
+import AddTaskModal from "../components/AddTaskModal";
 
 let didInit = false;
 
@@ -270,30 +271,31 @@ const Dashboard = () => {
                 <p className="text-sm">Create item</p>
               </div>
             ) : (
-              <div className="flex items-center gap-1 ml-1">
-                <input
-                  onChange={(e) => setNewTaskContent(e.target.value)}
-                  value={newTaskContent}
-                  className="rounded p-1 dark:bg-zinc-700 bg-white"
-                  placeholder="New task content.."
-                  autoFocus
-                />
-                <select
-                  onChange={(e) => setNewTaskDOW(+e.target.value)}
-                  value={newTaskDOW}
-                  className="h-8 rounded dark:bg-zinc-700 bg-white"
-                >
-                  <option value={0}>Sunday</option>
-                  <option value={1}>Monday</option>
-                  <option value={2}>Tuesday</option>
-                  <option value={3}>Wednesday</option>
-                  <option value={4}>Thursday</option>
-                  <option value={5}>Friday</option>
-                  <option value={6}>Saturday</option>
-                </select>
-                <IconButton icon={faCheckCircle} onClick={submitTask} />
-                <IconButton icon={faCircleXmark} onClick={clearCreating} />
-              </div>
+              <AddTaskModal />
+              // <div className="flex items-center gap-1 ml-1">
+              //   <input
+              //     onChange={(e) => setNewTaskContent(e.target.value)}
+              //     value={newTaskContent}
+              //     className="rounded p-1 dark:bg-zinc-700 bg-white"
+              //     placeholder="New task content.."
+              //     autoFocus
+              //   />
+              //   <select
+              //     onChange={(e) => setNewTaskDOW(+e.target.value)}
+              //     value={newTaskDOW}
+              //     className="h-8 rounded dark:bg-zinc-700 bg-white"
+              //   >
+              //     <option value={0}>Sunday</option>
+              //     <option value={1}>Monday</option>
+              //     <option value={2}>Tuesday</option>
+              //     <option value={3}>Wednesday</option>
+              //     <option value={4}>Thursday</option>
+              //     <option value={5}>Friday</option>
+              //     <option value={6}>Saturday</option>
+              //   </select>
+              //   <IconButton icon={faCheckCircle} onClick={submitTask} />
+              //   <IconButton icon={faCircleXmark} onClick={clearCreating} />
+              // </div>
             )}
             <WeekSwitcher />
             <div className="w-[107.406px]"></div>

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -271,7 +271,7 @@ const Dashboard = () => {
                 <p className="text-sm">Create item</p>
               </div>
             ) : (
-              <AddTaskModal />
+              <AddTaskModal onClose={() => setCreatingItem(false)} onSubmit={() => setCreatingItem(false)}/>
               // <div className="flex items-center gap-1 ml-1">
               //   <input
               //     onChange={(e) => setNewTaskContent(e.target.value)}

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -32,8 +32,6 @@ let didInit = false;
 
 const Dashboard = () => {
   const navigate = useNavigate();
-  const [newTaskContent, setNewTaskContent] = React.useState("");
-  const [newTaskDOW, setNewTaskDOW] = React.useState<Weekday>(0);
   const [showAddModal, setShowAddModal] = React.useState(false);
   const [userState, setUserState] = useRecoilState(authUserState);
   const [dayTasks, setDayTasksState] = useRecoilState(tasksState);
@@ -87,34 +85,6 @@ const Dashboard = () => {
   React.useEffect(() => {
     fetchData();
   }, [loggedIn]);
-
-  // submit a new task to the server
-  const submitTask = async () => {
-    const newTaskDate = moment().week(currentWeek).day(newTaskDOW).set({ hour: 8, minute: 0 });
-    const newTask: Partial<Task> = {
-      content: newTaskContent,
-      taskStatus: TaskStatus.ToDo,
-      taskDate: newTaskDate,
-    };
-    const addArgs: AddTaskArgs = {
-      uid: userState!.authUID,
-      taskData: newTask,
-    };
-    const newTaskRes = await addTask(addArgs);
-    if (newTaskRes) {
-      const newDayTasks: DayTasks = {
-        ...dayTasks,
-        [newTaskRes.taskDate.format("YYYY-MM-DD")]: {
-          tasks: [...getTasksByDate(dayTasks, newTaskDate), newTaskRes],
-        },
-      };
-      setDayTasksState(newDayTasks);
-    }
-
-    setNewTaskContent("");
-    setNewTaskDOW(0);
-    setShowAddModal(false);
-  };
 
   const dayOfWeekComponentsList: Array<JSX.Element> = [];
 
@@ -222,73 +192,22 @@ const Dashboard = () => {
     }
   };
 
-  const clearCreating = () => {
-    setNewTaskContent("");
-    setNewTaskDOW(0);
-    setShowAddModal(false);
-  };
-
-  useKeyPress(["Escape"], clearCreating);
   useKeyPress(["i"], () => setShowAddModal(true), null, true);
 
   return (
-    <div className="h-full bg-zinc-100 dark:bg-zinc-800 rounded py-2 px-1 flex flex-col mt-4 w-4/5">
+    <div className="h-full bg-zinc-100 dark:bg-zinc-800 rounded py-2 px-1 flex flex-col mt-4 w-4/5 min-w-[1000px]">
       {!loading ? (
         <>
           <div className="flex gap-3 items-center mb-3 justify-between ml-1">
             <CreateItemButton createItemAction={() => setShowAddModal(true)} />
-            {/* // <div
-              //   className="flex gap-2 bg-zinc-300 dark:bg-zinc-700 cursor-pointer p-1.5 rounded shadow ml-2 items-center"
-              //   onClick={() => setCreatingItem(true)}
-              //   role="button"
-              //   tabIndex={0}
-              //   onKeyDown={(e) =>
-              //     e.key === "Enter" ? setCreatingItem(true) : null
-              //   }
-              //   title="ctrl+i"
-              // >
-              //   <FontAwesomeIcon
-              //     icon={faCirclePlus}
-              //     className="hover:text-slate-300 rounded-full"
-              //     size="sm"
-              //   />
-              //   <p className="text-sm">Create item</p>
-              // </div> */}
-
             {showAddModal && (
               <AddTaskModal
                 onClose={() => setShowAddModal(false)}
                 onSubmit={() => setShowAddModal(false)}
               />
             )}
-
-            {/* // <div className="flex items-center gap-1 ml-1">
-              //   <input
-              //     onChange={(e) => setNewTaskContent(e.target.value)}
-              //     value={newTaskContent}
-              //     className="rounded p-1 dark:bg-zinc-700 bg-white"
-              //     placeholder="New task content.."
-              //     autoFocus
-              //   />
-              //   <select
-              //     onChange={(e) => setNewTaskDOW(+e.target.value)}
-              //     value={newTaskDOW}
-              //     className="h-8 rounded dark:bg-zinc-700 bg-white"
-              //   >
-              //     <option value={0}>Sunday</option>
-              //     <option value={1}>Monday</option>
-              //     <option value={2}>Tuesday</option>
-              //     <option value={3}>Wednesday</option>
-              //     <option value={4}>Thursday</option>
-              //     <option value={5}>Friday</option>
-              //     <option value={6}>Saturday</option>
-              //   </select>
-              //   <IconButton icon={faCheckCircle} onClick={submitTask} />
-              //   <IconButton icon={faCircleXmark} onClick={clearCreating} />
-              // </div> */}
-
             <WeekSwitcher />
-            <div className="w-[107.406px]"></div>
+            <div className="w-[8.5rem]"></div>
           </div>
           <DragDropContext onDragEnd={onDragEnd} onDragStart={onDragStart}>
             <div className="grid grid-cols-7 gap-1 h-full mx-1">{dayOfWeekComponentsList}</div>

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -190,7 +190,7 @@ const Dashboard = () => {
   useKeyPress(["i"], () => setShowAddModal(true), null, true);
 
   return (
-    <div className="h-full bg-zinc-100 dark:bg-zinc-800 rounded py-2 px-1 flex flex-col mt-4 w-4/5 min-w-[1000px]">
+    <div className="h-full bg-zinc-100 dark:bg-zinc-800 rounded py-2 px-1 flex flex-col mt-4 w-dashboard min-w-[1000px]">
       {!loading ? (
         <>
           <div className="flex gap-3 items-center mb-3 justify-between ml-1">

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -15,24 +15,18 @@ import { AddTaskArgs } from "../schema/Task";
 import { addTask, editOrder, getTasks } from "../services/tasks";
 import { Weekday } from "../schema/Weekday";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faCheckCircle,
-  faCirclePlus,
-  faCircleXmark,
-} from "@fortawesome/free-solid-svg-icons";
+import { faCheckCircle, faCirclePlus, faCircleXmark } from "@fortawesome/free-solid-svg-icons";
 import { useKeyPress } from "../hooks/useKeyPress";
 import IconButton from "../components/IconButton";
 import { authUser } from "../services/auth";
 import { ColorRing } from "react-loader-spinner";
 import DayOfWeekList from "../components/agenda-page/DayOfWeekList";
 import WeekSwitcher from "../components/agenda-page/WeekSwitcher";
-import {
-  DragDropContext,
-  DropResult,
-} from "@hello-pangea/dnd";
+import { DragDropContext, DropResult } from "@hello-pangea/dnd";
 import { getTasksByDate } from "../domain/TaskUtils";
 import { getWeekdayFromDay } from "../domain/WeekdayUtils";
 import AddTaskModal from "../components/AddTaskModal";
+import CreateItemButton from "../components/agenda-page/CreateItemButton";
 
 let didInit = false;
 
@@ -40,7 +34,7 @@ const Dashboard = () => {
   const navigate = useNavigate();
   const [newTaskContent, setNewTaskContent] = React.useState("");
   const [newTaskDOW, setNewTaskDOW] = React.useState<Weekday>(0);
-  const [creatingItem, setCreatingItem] = React.useState(false);
+  const [showAddModal, setShowAddModal] = React.useState(false);
   const [userState, setUserState] = useRecoilState(authUserState);
   const [dayTasks, setDayTasksState] = useRecoilState(tasksState);
   const [loading, setLoading] = useRecoilState(loadingState);
@@ -96,7 +90,7 @@ const Dashboard = () => {
 
   // submit a new task to the server
   const submitTask = async () => {
-    const newTaskDate = moment().week(currentWeek).day(newTaskDOW).set({hour: 8, minute: 0});
+    const newTaskDate = moment().week(currentWeek).day(newTaskDOW).set({ hour: 8, minute: 0 });
     const newTask: Partial<Task> = {
       content: newTaskContent,
       taskStatus: TaskStatus.ToDo,
@@ -119,7 +113,7 @@ const Dashboard = () => {
 
     setNewTaskContent("");
     setNewTaskDOW(0);
-    setCreatingItem(false);
+    setShowAddModal(false);
   };
 
   const dayOfWeekComponentsList: Array<JSX.Element> = [];
@@ -128,9 +122,7 @@ const Dashboard = () => {
   // it's not guaranteed to be initialized
   if (userState) {
     for (let i = 0; i < 7; i++) {
-      dayOfWeekComponentsList.push(
-        <DayOfWeekList dayOfWeek={i} key={i} uid={userState.authUID} />
-      );
+      dayOfWeekComponentsList.push(<DayOfWeekList dayOfWeek={i} key={i} uid={userState.authUID} />);
     }
   }
 
@@ -145,9 +137,7 @@ const Dashboard = () => {
       return;
     }
 
-    const sourceDate = moment()
-      .week(currentWeek)
-      .day(getWeekdayFromDay(result.source.droppableId));
+    const sourceDate = moment().week(currentWeek).day(getWeekdayFromDay(result.source.droppableId));
     const destinationDate = moment()
       .week(currentWeek)
       .day(getWeekdayFromDay(result.destination.droppableId));
@@ -170,27 +160,24 @@ const Dashboard = () => {
 
       // get the task before the newly reordered task if it exists
       const prevTaskID =
-        result.destination.index > 0
-          ? items[result.destination.index - 1].taskID
-          : "";
-      
+        result.destination.index > 0 ? items[result.destination.index - 1].taskID : "";
+
       // get the task after the newly reordered task if it exists
       const nextTaskID =
         result.destination.index < items.length - 1
           ? items[result.destination.index + 1].taskID
           : "";
 
-      const args : EditOrderArgs = {
+      const args: EditOrderArgs = {
         uid: userState!.authUID,
         taskID: reorderedItem.taskID,
         initialDate: reorderedItem.taskDate.toISOString(),
         newDate: reorderedItem.taskDate.toISOString(),
         prevTaskID,
         nextTaskID,
-      }
+      };
 
       await editOrder(args);
-
     } else {
       const sourceItems = [...sourceTasks];
       const destinationItems = [...destinationTasks];
@@ -214,65 +201,68 @@ const Dashboard = () => {
 
       // get the task before the newly reordered task if it exists
       const prevTaskID =
-        result.destination.index > 0
-          ? destinationItems[result.destination.index - 1].taskID
-          : "";
-      
+        result.destination.index > 0 ? destinationItems[result.destination.index - 1].taskID : "";
+
       // get the task after the newly reordered task if it exists
       const nextTaskID =
         result.destination.index < destinationItems.length - 1
           ? destinationItems[result.destination.index + 1].taskID
           : "";
 
-      const args : EditOrderArgs = {
+      const args: EditOrderArgs = {
         uid: userState!.authUID,
         taskID: reorderedItem.taskID,
         initialDate: reorderedItem.taskDate.toISOString(),
         newDate: newDate.toISOString(),
         prevTaskID,
         nextTaskID,
-      }
+      };
 
       await editOrder(args);
-
     }
   };
 
   const clearCreating = () => {
     setNewTaskContent("");
     setNewTaskDOW(0);
-    setCreatingItem(false);
+    setShowAddModal(false);
   };
 
   useKeyPress(["Escape"], clearCreating);
-  useKeyPress(["i"], () => setCreatingItem(true), null, true);
+  useKeyPress(["i"], () => setShowAddModal(true), null, true);
 
   return (
     <div className="h-full bg-zinc-100 dark:bg-zinc-800 rounded py-2 px-1 flex flex-col mt-4 w-4/5">
       {!loading ? (
         <>
-          <div className="flex gap-3 items-center mb-3 justify-between">
-            {!creatingItem ? (
-              <div
-                className="flex gap-2 bg-zinc-300 dark:bg-zinc-700 cursor-pointer p-1.5 rounded shadow ml-2 items-center"
-                onClick={() => setCreatingItem(true)}
-                role="button"
-                tabIndex={0}
-                onKeyDown={(e) =>
-                  e.key === "Enter" ? setCreatingItem(true) : null
-                }
-                title="ctrl+i"
-              >
-                <FontAwesomeIcon
-                  icon={faCirclePlus}
-                  className="hover:text-slate-300 rounded-full"
-                  size="sm"
-                />
-                <p className="text-sm">Create item</p>
-              </div>
-            ) : (
-              <AddTaskModal onClose={() => setCreatingItem(false)} onSubmit={() => setCreatingItem(false)}/>
-              // <div className="flex items-center gap-1 ml-1">
+          <div className="flex gap-3 items-center mb-3 justify-between ml-1">
+            <CreateItemButton createItemAction={() => setShowAddModal(true)} />
+            {/* // <div
+              //   className="flex gap-2 bg-zinc-300 dark:bg-zinc-700 cursor-pointer p-1.5 rounded shadow ml-2 items-center"
+              //   onClick={() => setCreatingItem(true)}
+              //   role="button"
+              //   tabIndex={0}
+              //   onKeyDown={(e) =>
+              //     e.key === "Enter" ? setCreatingItem(true) : null
+              //   }
+              //   title="ctrl+i"
+              // >
+              //   <FontAwesomeIcon
+              //     icon={faCirclePlus}
+              //     className="hover:text-slate-300 rounded-full"
+              //     size="sm"
+              //   />
+              //   <p className="text-sm">Create item</p>
+              // </div> */}
+
+            {showAddModal && (
+              <AddTaskModal
+                onClose={() => setShowAddModal(false)}
+                onSubmit={() => setShowAddModal(false)}
+              />
+            )}
+
+            {/* // <div className="flex items-center gap-1 ml-1">
               //   <input
               //     onChange={(e) => setNewTaskContent(e.target.value)}
               //     value={newTaskContent}
@@ -295,13 +285,13 @@ const Dashboard = () => {
               //   </select>
               //   <IconButton icon={faCheckCircle} onClick={submitTask} />
               //   <IconButton icon={faCircleXmark} onClick={clearCreating} />
-              // </div>
-            )}
+              // </div> */}
+
             <WeekSwitcher />
             <div className="w-[107.406px]"></div>
           </div>
           <DragDropContext onDragEnd={onDragEnd} onDragStart={onDragStart}>
-            <div className="grid grid-cols-7 gap-1 h-full">{dayOfWeekComponentsList}</div>
+            <div className="grid grid-cols-7 gap-1 h-full mx-1">{dayOfWeekComponentsList}</div>
           </DragDropContext>
         </>
       ) : (

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,15 +1,18 @@
 /** @type {import('tailwindcss').Config} */
 
-const plugin = require('tailwindcss/plugin');
+const plugin = require("tailwindcss/plugin");
 
 module.exports = {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {
+      spacing: {
+        dashboard: "97%",
+      },
       textShadow: {
-        sm: '0 1px 2px var(--tw-shadow-color)',
-        DEFAULT: '0 2px 4px var(--tw-shadow-color)',
-        lg: '0 8px 16px var(--tw-shadow-color)',
+        sm: "0 1px 2px var(--tw-shadow-color)",
+        DEFAULT: "0 2px 4px var(--tw-shadow-color)",
+        lg: "0 8px 16px var(--tw-shadow-color)",
       },
       colors: {
         "light-gray": "#32373a",
@@ -28,12 +31,12 @@ module.exports = {
     plugin(function ({ matchUtilities, theme }) {
       matchUtilities(
         {
-          'text-shadow': (value) => ({
+          "text-shadow": (value) => ({
             textShadow: value,
           }),
         },
-        { values: theme('textShadow') }
-      )
+        { values: theme("textShadow") }
+      );
     }),
   ],
   darkMode: "class",

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -19,6 +19,7 @@ module.exports = {
         "disc-dark-2": "#36393e",
         "disc-dark-3": "#282b30",
         "disc-dark-4": "#1e2124",
+        "red-450": "rgb(233 102 102)",
       },
     },
   },


### PR DESCRIPTION
## Modal Component
- Created a component that uses a ReactDOM "portal" to the root div, so it lives on the full page
- Styled by default to have a header, body that is passed in, and footer with buttons
- All is heavily customizable with props

## Add Task Modal
- Sort of a proof-of-concept modal, but also is important
- Replaces old expand-functionality of create item button
- Allows users to actually select a task date
- TODO: For users that like to quick-create tasks, we should add a "Copy to new", or maybe "Submit and create new" option instead of automatically closing the modal after task submission

### Other stuff
- Restyled the dashboard as a css grid - flexbox doesn't make too much sense here
- With the grid, the day-of-week columns are a bit more rigid, which I think is good: no more weird wrapping and inconsistent column sizes
- More reusable components (am I a React GOD?) - Field, SelectField, Button 


### Closed issues:
- WD-48
- WD-42 (Create task modal)
- WD-32 (Week changer shifting bug, no longer an issue as the create button no longer expands. I will close the PR I had out for this bug if this is approved)